### PR TITLE
Add fix for 5FXN alignment by trimming data.

### DIFF
--- a/sidechainnet/create.py
+++ b/sidechainnet/create.py
@@ -17,7 +17,7 @@ pr.confProDy(verbosity="none")
 
 from sidechainnet.download_and_parse import download_sidechain_data, load_data, save_data
 from sidechainnet.utils.proteinnet import parse_raw_proteinnet
-from sidechainnet.utils.alignment import init_aligner
+from sidechainnet.utils.alignment import init_aligner, manually_adjust_data
 from sidechainnet.utils.structure import NUM_PREDICTED_COORDS
 
 
@@ -38,6 +38,8 @@ def combine(pn_entry, sc_entry, aligner, pnid):
     if "secondary" in pn_entry:
         print("WARNING: secondary structure information is not yet supported. "
               "As of May 2020, it is not included in ProteinNet.")
+
+    sc_entry = manually_adjust_data(pnid, sc_entry)
 
     can_be_merged, mask, alignment, warning = can_be_directly_merged(aligner,
                                                             pn_entry["primary"],

--- a/sidechainnet/utils/alignment.py
+++ b/sidechainnet/utils/alignment.py
@@ -335,3 +335,29 @@ def pad_seq_with_mask(seq, mask):
         elif m == "-":
             new_seq += "-"
     return new_seq
+
+
+def manually_adjust_data(pnid, sc_entry):
+    """ Returns a modified version of sc_entry to fix some issues manually.
+
+    Args:
+        pnid: string, ProteinNet ID
+        sc_entry: dictionary containing "seq", "ang", "crd" data
+
+    Returns:
+        If sc_entry must be modified, then it is corrected and returned.
+        Otherwise, it is returned without modifications.
+
+    """
+
+    # In the case of 5FXN, ProDy mistakenly parses two extranneous residues "VK"
+    # from the file due to the file not distinguishing these resides as being
+    # on a different segment. We can manually remove this data here before
+    # proceeding with alignment.
+    # https://github.com/prody/ProDy/issues/1045
+    if "5FXN" in pnid and len(sc_entry["seq"]) == 316 and sc_entry["seq"][-3:] == "VVK":
+        sc_entry["seq"] = sc_entry["seq"][:-2]
+        sc_entry["ang"] = sc_entry["ang"][:-2]
+        sc_entry["crd"] = sc_entry["crd"][:-NUM_PREDICTED_COORDS*2]
+
+    return sc_entry


### PR DESCRIPTION
https://github.com/prody/ProDy/issues/1045

## Description
Manually trims the last two observed residues from 5FXN because they are parsed incorrectly. 
