### PR TITLE
Improve API and structure building methods. Discuss alpha-carbon only data.

### DIFF
--- a/sidechainnet/__init__.py
+++ b/sidechainnet/__init__.py
@@ -1,5 +1,5 @@
-"""
-SideChainNet
+"""SidechainNet.
+
 A protein structure prediction data set that includes sidechain information. Directly
 extends ProteinNet by Mohammed AlQuraishi.
 """
@@ -27,6 +27,9 @@ from ._version import get_versions
 from .structure.StructureBuilder import StructureBuilder
 from .structure.BatchedStructureBuilder import BatchedStructureBuilder
 from .utils.load import load
+
+from .utils.download import VALID_SPLITS, DATA_SPLITS
+
 
 versions = get_versions()
 __version__ = versions['version']

--- a/sidechainnet/dataloaders/collate.py
+++ b/sidechainnet/dataloaders/collate.py
@@ -9,7 +9,7 @@ from sidechainnet.dataloaders.SimilarLengthBatchSampler import SimilarLengthBatc
 from sidechainnet.dataloaders.ProteinDataset import ProteinDataset
 from sidechainnet.utils.sequence import VOCAB, DSSPVocabulary
 from sidechainnet.structure.build_info import NUM_COORDS_PER_RES
-from sidechainnet.utils.download import VALID_SPLITS, MAX_SEQ_LEN
+from sidechainnet.utils.download import MAX_SEQ_LEN, VALID_SPLITS
 
 
 Batch = collections.namedtuple("Batch",
@@ -237,13 +237,13 @@ def prepare_dataloaders(data,
             downsample=train_eval_downsample))
 
     valid_loaders = {}
-    for split in VALID_SPLITS:
+    for vsplit in VALID_SPLITS:
         valid_loader = torch.utils.data.DataLoader(ProteinDataset(
-            data[f'valid-{split}'], f'valid-{split}', data['settings'], data['date']),
+            data[vsplit], vsplit, data['settings'], data['date']),
                                                    num_workers=num_workers,
                                                    batch_size=batch_size,
                                                    collate_fn=collate_fn)
-        valid_loaders[split] = valid_loader
+        valid_loaders[vsplit] = valid_loader
 
     test_loader = torch.utils.data.DataLoader(ProteinDataset(data['test'], 'test',
                                                              data['settings'],
@@ -257,6 +257,6 @@ def prepare_dataloaders(data,
         'train-eval': train_eval_loader,
         'test': test_loader
     }
-    dataloaders.update({f'valid-{split}': valid_loaders[split] for split in VALID_SPLITS})
+    dataloaders.update({vsplit: valid_loaders[vsplit] for vsplit in VALID_SPLITS})
 
     return dataloaders

--- a/sidechainnet/structure/BatchedStructureBuilder.py
+++ b/sidechainnet/structure/BatchedStructureBuilder.py
@@ -1,3 +1,5 @@
+"""A convenience class for generating multiple protein structures simultaneously."""
+
 import numpy as np
 
 from sidechainnet.dataloaders.collate import pad_for_batch
@@ -7,13 +9,12 @@ import sidechainnet as scn
 
 
 class BatchedStructureBuilder(object):
+    """BatchedStructureBuilder enables users to generate a batch of protein structures."""
 
-    # Assumes sequence of integers
-
-    def __init__(self, seq_batch, ang_batch=None, crd_batch=None, nerf_method="sn_nerf"):
+    def __init__(self, seq_batch, ang_batch=None, crd_batch=None, nerf_method="standard"):
         """Construct a object capable of generating batches of StructureBuilders.
 
-        A BatchedStructreBuilder essentially is a container for multiple StructureBuilder
+        A BatchedStructureBuilder essentially is a container for multiple StructureBuilder
         objects, one for each protein in the given batch. As such, it implements much
         of the same functionality, but simply iterates over multiple proteins.
 
@@ -26,9 +27,10 @@ class BatchedStructureBuilder(object):
                 cartesian coordinates that represent protein structure. Defaults to None.
             return_as_list (bool, optional): Boolean value. If True, returns constructed
                 coordinates Defaults to True.
-            nerf_method (str, optional): Which NeRF implementation to use. "nerf" uses the
-                standard NeRF formulation described in many papers. "sn-nerf" uses an
-                optimized version with less vector normalizations. Defaults to "sn_nerf".
+            nerf_method (str, optional): Which NeRF implementation to use. "standard" uses
+                the standard NeRF formulation described in many papers. "sn_nerf" uses an
+                optimized version with less vector normalizations. Defaults to
+                "standard".
 
         Raises:
             ValueError: May raise ValueError when asked to generate structures from angles
@@ -56,7 +58,8 @@ class BatchedStructureBuilder(object):
         for i, (seq, ang_or_crd) in enumerate(zip(seq_batch, self.ang_or_crd_batch)):
             seq, ang_or_crd = unpad_tensors(seq, ang_or_crd)
             try:
-                self.structure_builders.append(scn.StructureBuilder(seq, ang_or_crd))
+                self.structure_builders.append(
+                    scn.StructureBuilder(seq, ang_or_crd, nerf_method=nerf_method))
             except ValueError as e:
                 if self.uses_coords:
                     raise e
@@ -77,7 +80,7 @@ class BatchedStructureBuilder(object):
 
         Returns:
             List or torch.float32 tensor: Depending on the value of return_as_list,
-            returns either a Python list of constructued coordinates for each protein, or
+            returns either a Python list of constructed coordinates for each protein, or
             a padded tensor containing the coordinates.
         """
         all_coords = []

--- a/sidechainnet/structure/BatchedStructureBuilder.py
+++ b/sidechainnet/structure/BatchedStructureBuilder.py
@@ -87,6 +87,20 @@ class BatchedStructureBuilder(object):
             self._missing_residue_error(idx)
         return self.structure_builders[idx].to_pdb(path, title)
 
+    def to_gltf(self, idx, path, title=None):
+        """Save protein structure as a GLTF (3D-object) file to given path.
+
+        Args:
+            idx (int): index of the StructureBuilder to visualize.
+            path (str): Path to save GLTF file.
+            title (str, optional): Title of generated structure (default = 'pred').
+        """
+        if not 0 <= idx < len(self.structure_builders):
+            raise ValueError("provided index is not available.")
+        if idx in self.unbuildable_structures:
+            self._missing_residue_error(idx)
+        return self.structure_builders[idx].to_gltf(path, title)
+
     def _missing_residue_error(self, structure_idx):
         """Raises a ValueError describing missing residues."""
         missing_loc = np.where((self.ang_or_crd_batch[structure_idx] == 0).all(axis=-1))

--- a/sidechainnet/structure/StructureBuilder.py
+++ b/sidechainnet/structure/StructureBuilder.py
@@ -400,7 +400,7 @@ class ResidueBuilder(object):
             # Select appropriate torsion angle, or infer if part of a planar configuration
             if type(torsion) is str and torsion == "p":
                 torsion = self.ang[SC_ANGLES_START_POS + i]
-            elif type(torsion) is str and torsion == "i" and last_torsion:
+            elif type(torsion) is str and torsion == "i" and last_torsion is not None:
                 torsion = last_torsion - np.pi
 
             new_pt = nerf(a,

--- a/sidechainnet/structure/StructureBuilder.py
+++ b/sidechainnet/structure/StructureBuilder.py
@@ -39,7 +39,7 @@ class StructureBuilder(object):
         # Perhaps the user mistakenly passed coordinates for the angle arguments
         if ang is not None and crd is None and ang.shape[-1] == 3:
             self.coords = ang
-            self.ang =  None
+            self.ang = None
         elif crd is not None and ang is None:
             self.ang = None
             self.coords = crd
@@ -191,7 +191,7 @@ class StructureBuilder(object):
             if self.data_type == 'numpy':
                 self.pdb_creator = PdbBuilder(self.seq_as_str, self.coords)
             else:
-                self.pdb_creator = PdbBuilder(self.seq_as_str, 
+                self.pdb_creator = PdbBuilder(self.seq_as_str,
                                               self.coords.detach().numpy())
 
     def to_pdb(self, path, title="pred"):
@@ -260,8 +260,8 @@ class ResidueBuilder(object):
             prev_ang : Angle tensor (1 X NUM_PREDICTED_ANGLES) of previous reside, upon
                 which this residue is extending.
         """
-        if (not isinstance(name, np.int64) and not isinstance(name, np.int32)
-                and not isinstance(name, torch.Tensor)):
+        if (not isinstance(name, np.int64) and not isinstance(name, np.int32) and
+                not isinstance(name, torch.Tensor)):
             raise ValueError("Expected integer AA code." + str(name.shape) +
                              str(type(name)))
         if isinstance(angles, np.ndarray):

--- a/sidechainnet/structure/StructureBuilder.py
+++ b/sidechainnet/structure/StructureBuilder.py
@@ -310,7 +310,7 @@ class ResidueBuilder(object):
                     # Placing N
                     t = self.prev_res.ang[4]  # thetas["ca-c-n"]
                     b = BB_BUILD_INFO["BONDLENS"]["c-n"]
-                    pb = b = BB_BUILD_INFO["BONDLENS"]["ca-c"]
+                    pb = b = BB_BUILD_INFO["BONDLENS"]["ca-c"]  # pb is previous bond len
                     dihedral = self.prev_res.ang[1]  # psi of previous residue
                 elif j == 1:
                     # Placing Ca
@@ -337,8 +337,14 @@ class ResidueBuilder(object):
                         # the angle for placing oxygen is opposite to psi of current res
                         dihedral = self.ang[1] - np.pi
 
-                next_pt = nerf(pts[-3], pts[-2], pts[-1], b, t, dihedral, pb,
-                               self.nerf_method)
+                next_pt = nerf(pts[-3],
+                               pts[-2],
+                               pts[-1],
+                               b,
+                               t,
+                               dihedral,
+                               l_bc=pb,
+                               nerf_method=self.nerf_method)
                 pts.append(next_pt)
             self.bb = pts[3:]
 
@@ -362,8 +368,8 @@ class ResidueBuilder(object):
             torch.tensor(BB_BUILD_INFO["BONDLENS"]["c-o"]),
             torch.tensor(BB_BUILD_INFO["BONDANGS"]["ca-c-o"]),
             self.ang[1] - np.pi,  # opposite to current residue's psi
-            torch.tensor(BB_BUILD_INFO["BONDLENS"]["ca-c"]),  # Previous bond length
-            self.nerf_method)
+            l_bc=torch.tensor(BB_BUILD_INFO["BONDLENS"]["ca-c"]),  # Previous bond length
+            nerf_method=self.nerf_method)
         return [n, ca, c, o]
 
     def build_sc(self):
@@ -397,7 +403,14 @@ class ResidueBuilder(object):
             elif type(torsion) is str and torsion == "i" and last_torsion:
                 torsion = last_torsion - np.pi
 
-            new_pt = nerf(a, b, c, pbond_len, bond_len, angle, torsion)
+            new_pt = nerf(a,
+                          b,
+                          c,
+                          bond_len,
+                          angle,
+                          torsion,
+                          l_bc=pbond_len,
+                          nerf_method=self.nerf_method)
             self.pts[atom_names[-1]] = new_pt
             self.sc.append(new_pt)
             last_torsion = torsion

--- a/sidechainnet/structure/structure.py
+++ b/sidechainnet/structure/structure.py
@@ -24,11 +24,11 @@ def angles_to_coords(angles, seq, remove_batch_padding=False):
 
 
 def generate_coords(angles, input_seq, device):
-    """ Returns a protein's coordinates generated from its angles and sequence.
+    """Return a protein's coordinates generated from its angles and sequence.
 
-    Given a tensor of angles (L x NUM_PREDICTED_ANGLES), produces the entire
-    set of cartesian coordinates using the NeRF method, (L x A` x 3),
-    where A` is the number of atoms generated (depends on amino acid sequence).
+    Given a tensor of angles (L x NUM_PREDICTED_ANGLES), produces the entire set
+    of cartesian coordinates using the NeRF method, (L x A` x 3), where A` is
+    the number of atoms generated (depends on amino acid sequence).
     """
     sb = StructureBuilder.StructureBuilder(input_seq, angles, device)
     return sb.build()
@@ -88,9 +88,7 @@ def determine_missing_positions(ang_or_coord_matrix):
 
 
 def deg2rad(angle):
-    """
-    Converts an angle in degrees to radians.
-    """
+    """Convert an angle in degrees to radians."""
     return angle * np.pi / 180.
 
 

--- a/sidechainnet/structure/structure.py
+++ b/sidechainnet/structure/structure.py
@@ -34,28 +34,69 @@ def generate_coords(angles, input_seq, device):
     return sb.build()
 
 
-def nerf(a, b, c, l, theta, chi):
-    """
-    Natural extension reference frame method for placing the 4th atom given
-    atoms 1-3 and the relevant angle inforamation. This code was originally
-    written by Rohit Bhattacharya (rohit.bhattachar@gmail.com,
-    https://github.com/rbhatta8/protein-design/blob/master/nerf.py) and I
-    have extended it to work with PyTorch. His original documentation is
-    below:
+def nerf(a, b, c, l, theta, chi, l_bc=None, nerf_method="standard"):
+    """Compute the position of point d given 3 previous points and several parameters.
 
-    Nerf method of finding 4th coord (d) in cartesian space
-        Params:
-            a, b, c : coords of 3 points
-            l : bond length between c and d
-            theta : bond angle between b, c, d (in degrees)
-            chi : dihedral using a, b, c, d (in degrees)
-        Returns:
-            d: tuple of (x, y, z) in cartesian space
+    This function uses either sn_nerf or standard_nerf depending on the presence of l_bc.
+    Both sn_nerf and standard_nerf follow the formulations in the paper by Jerod Parsons
+    et al. https://doi.org/10.1002/jcc.20237 titled "Practical conversion from torsion
+    space to Cartesian space for in silico protein synthesis."
+
+    Args:
+        a (torch.float32 tensor): (3 x 1) tensor describing point a.
+        b (torch.float32 tensor): (3 x 1) tensor describing point b.
+        c (torch.float32 tensor): (3 x 1) tensor describing point c.
+        l_cd (torch.float32 tensor): (1) tensor describing the length between points
+            c & d.
+        theta (torch.float32 tensor): (1) tensor describing angle between points b, c,
+            and d.
+        chi (torch.float32 tensor): (1) tensor describing dihedral angle between points
+            a, b, c, and d.
+        l_bc (torch.float32 tensor, optional): (1) tensor describing length between points
+            b and c.
+        nerf_method (str, optional): Which NeRF implementation to use. "standard" uses
+            the standard NeRF formulation described in many papers. "sn_nerf" uses an
+            optimized version with less vector normalizations. Defaults to
+            "standard".
     """
-    # calculate unit vectors AB and BC
+    if nerf_method == "standard" or l_bc is None:
+        return standard_nerf(a, b, c, l, theta, chi)
+    elif nerf_method == "sn_nerf" and l_bc is not None:
+        return sn_nerf(a, b, c, l, theta, chi, l_bc)
+    else:
+        raise ValueError("l_bc must be provided for sn_nerf.")
+
+
+def standard_nerf(a, b, c, l, theta, chi):
+    """Compute the position of point d given 3 previous points and angle information.
+
+    This implementation is based on the one originally written by Rohit Bhattacharya
+    (rohit.bhattachar@gmail.com,
+    https://github.com/rbhatta8/protein-design/blob/master/nerf.py). I have extended it to
+    work with PyTorch. Original equation from https://doi.org/10.1002/jcc.20237.
+
+    Args:
+        a (torch.float32 tensor): (3 x 1) tensor describing point a.
+        b (torch.float32 tensor): (3 x 1) tensor describing point b.
+        c (torch.float32 tensor): (3 x 1) tensor describing point c.
+        l_cd (torch.float32 tensor): (1) tensor describing the length between points
+            c & d.
+        theta (torch.float32 tensor): (1) tensor describing angle between points b, c,
+            and d.
+        chi (torch.float32 tensor): (1) tensor describing dihedral angle between points
+            a, b, c, and d.
+
+    Raises:
+        ValueError: Raises ValueError when value of theta is not in [-pi, pi].
+
+    Returns:
+        torch.float32 tensor: (3 x 1) tensor describing coordinates of point c after
+        placement using points a, b, c, and several parameters.
+    """
     if not (-np.pi <= theta <= np.pi):
         raise ValueError(f"theta must be in radians and in [-pi, pi]. theta = {theta}")
 
+    # calculate unit vectors AB and BC
     W_hat = torch.nn.functional.normalize(b - a, dim=0)
     x_hat = torch.nn.functional.normalize(c - b, dim=0)
 
@@ -76,10 +117,55 @@ def nerf(a, b, c, l, theta, chi):
     ])
 
     # calculate with rotation as our final output
-    # TODO: is the squeezing necessary?
     d = d.unsqueeze(1).to(torch.float32)
     res = c + torch.mm(M, d).squeeze()
     return res.squeeze()
+
+
+def sn_nerf(a, b, c, l_cd, theta, chi, l_bc):
+    """Return coordinates for point d given previous points & parameters. Optimized NeRF.
+
+    This function has been optimized from the original nerf to be about 20% faster. It
+    contains fewer normalization steps and total calculations than the original
+    formulation. See https://doi.org/10.1002/jcc.20237 for details.
+
+    Args:
+        a (torch.float32 tensor): (3 x 1) tensor describing point a.
+        b (torch.float32 tensor): (3 x 1) tensor describing point b.
+        c (torch.float32 tensor): (3 x 1) tensor describing point c.
+        l_cd (torch.float32 tensor): (1) tensor describing the length between points
+            c & d.
+        theta (torch.float32 tensor): (1) tensor describing angle between points b, c,
+            and d.
+        chi (torch.float32 tensor): (1) tensor describing dihedral angle between points
+            a, b, c, and d.
+        l_bc (torch.float32 tensor): (1) tensor describing length between points b and c.
+
+    Raises:
+        ValueError: Raises ValueError when value of theta is not in [-pi, pi].
+
+    Returns:
+        torch.float32 tensor: (3 x 1) tensor describing coordinates of point c after
+        placement using points a, b, c, and several parameters.
+    """
+    if not (-np.pi <= theta <= np.pi):
+        raise ValueError(f"theta must be in radians and in [-pi, pi]. theta = {theta}")
+    AB = b - a
+    BC = c - b
+    bc = BC / l_bc
+    n = torch.nn.functional.normalize(torch.cross(AB, bc), dim=0)
+    n_x_bc = torch.cross(n, bc)
+
+    M = torch.stack([bc, n_x_bc, n], dim=1)
+
+    D2 = torch.stack([
+        -l_cd * torch.cos(theta), l_cd * torch.sin(theta) * torch.cos(chi),
+        l_cd * torch.sin(theta) * torch.sin(chi)
+    ]).to(torch.float32).unsqueeze(1)
+
+    D = torch.mm(M, D2).squeeze()
+
+    return D + c
 
 
 def determine_missing_positions(ang_or_coord_matrix):

--- a/sidechainnet/utils/__init__.py
+++ b/sidechainnet/utils/__init__.py
@@ -1,5 +1,0 @@
-"""Utility functions for SidechainNet."""
-from .download import VALID_SPLITS
-
-VALID_SPLITS_STRS = [f'valid-{s}' for s in VALID_SPLITS]
-DATA_SPLITS = ['train', 'test'] + VALID_SPLITS_STRS

--- a/sidechainnet/utils/__init__.py
+++ b/sidechainnet/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions for SidechainNet."""
+from .download import VALID_SPLITS
+
+VALID_SPLITS_STRS = [f'valid-{s}' for s in VALID_SPLITS]
+DATA_SPLITS = ['train', 'test'] + VALID_SPLITS_STRS

--- a/sidechainnet/utils/download.py
+++ b/sidechainnet/utils/download.py
@@ -14,7 +14,9 @@ from sidechainnet.utils.measure import get_seq_coords_and_angles, no_nans_infs_a
 from sidechainnet.utils.parse import get_chain_from_astral_id, parse_astral_summary_file, parse_dssp_file
 
 MAX_SEQ_LEN = 10_000  # An arbitrarily large upper-bound on sequence lengths
-VALID_SPLITS = [10, 20, 30, 40, 50, 70, 90]
+VALID_SPLITS_INTS = [10, 20, 30, 40, 50, 70, 90]
+VALID_SPLITS = [f'valid-{s}' for s in VALID_SPLITS_INTS]
+DATA_SPLITS = ['train', 'test'] + VALID_SPLITS
 with open(get_data("astral_data.txt"), "r") as astral_file:
     ASTRAL_ID_MAPPING = parse_astral_summary_file(astral_file.read().splitlines())
 D_AMINO_ACID_CODES = [
@@ -358,7 +360,7 @@ def add_proteinnetID_to_idx_mapping(data):
     Useful if you'd like to quickly extract a certain protein.
     """
     d = {}
-    for subset in ["train", "test"] + [f"valid-{split}" for split in VALID_SPLITS]:
+    for subset in DATA_SPLITS:
         for idx, pnid in enumerate(data[subset]["ids"]):
             d[pnid] = {"subset": subset, "idx": idx}
 

--- a/sidechainnet/utils/download.py
+++ b/sidechainnet/utils/download.py
@@ -235,16 +235,16 @@ def get_chain_from_trainid(pnid):
     try:
         chain = pr.parsePDB(pdbid, chain=chid, model=chnum)
         if not chain:
-            chain = pr.parseCIF(pdbid, chain=chid, model=chnum)
+            chain = pr.parseMMCIF(pdbid, chain=chid, model=chnum)
             use_pdb = False
     # If the file is too large, then we can download the CIF instead
     except OSError:
         try:
-            chain = pr.parseCIF(pdbid, chain=chid, model=chnum)
+            chain = pr.parseMMCIF(pdbid, chain=chid, model=chnum)
             use_pdb = False
         except IndexError:
             try:
-                chain = pr.parseCIF(pdbid, chain=chid, model=1)
+                chain = pr.parseMMCIF(pdbid, chain=chid, model=1)
                 use_pdb = False
                 modified_model_number = True
             except Exception as e:
@@ -258,7 +258,7 @@ def get_chain_from_trainid(pnid):
     except (pr.proteins.pdbfile.PDBParseError, IndexError):
         # For now, if the requested coordinate set doesn't exist, then we will
         # default to using the only (first) available coordinate set
-        struct = pr.parsePDB(pdbid, chain=chid) if use_pdb else pr.parseCIF(pdbid,
+        struct = pr.parsePDB(pdbid, chain=chid) if use_pdb else pr.parseMMCIF(pdbid,
                                                                             chain=chid)
         if struct and chnum > 1:
             try:

--- a/sidechainnet/utils/load.py
+++ b/sidechainnet/utils/load.py
@@ -354,6 +354,7 @@ def filter_dictionary_by_missing_residues(raw_data):
                                                       train['res'], train['sec']):
         total_entires += 1
         if "-" in msk:
+            n_filtered_entries += 1
             continue
         else:
             new_data["seq"].append(seq)

--- a/sidechainnet/utils/organize.py
+++ b/sidechainnet/utils/organize.py
@@ -7,7 +7,7 @@ import pickle
 
 import numpy as np
 
-from sidechainnet.utils.download import VALID_SPLITS
+from sidechainnet.utils.download import DATA_SPLITS, VALID_SPLITS
 
 
 def validate_data_dict(data):
@@ -21,11 +21,11 @@ def validate_data_dict(data):
             l == num_items for l in map(len, [data[subset][k] for k in items_recorded])
         ]), f"{subset} lengths don't match."
 
-    for split in VALID_SPLITS:
-        valid_len = len(data[f"valid-{split}"]["seq"])
+    for vsplit in VALID_SPLITS:
+        valid_len = len(data[vsplit]["seq"])
         assert all([
             l == valid_len
-            for l in map(len, [data[f"valid-{split}"][k] for k in ["ang", "ids", "crd"]])
+            for l in map(len, [data[vsplit][k] for k in ["ang", "ids", "crd"]])
         ]), "Valid lengths don't match."
 
 
@@ -51,7 +51,7 @@ def create_empty_dictionary():
     }
 
     validation_subdict = {
-        f"valid-{split}": copy.deepcopy(basic_data_entries) for split in VALID_SPLITS
+        vsplit: copy.deepcopy(basic_data_entries) for vsplit in VALID_SPLITS
     }
     data.update(validation_subdict)
 
@@ -130,7 +130,7 @@ def organize_data(scnet_data, proteinnet_dir, casp_version, thinning):
             n_proteins += 1
 
     # Sort each split of data by length, ascending
-    for split in ["train", "test"] + [f"valid-{vs}" for vs in VALID_SPLITS]:
+    for split in DATA_SPLITS:
         organized_data[split] = sort_datasplit(organized_data[split])
 
     # Add settings


### PR DESCRIPTION
## Improvements
This pull request will make several improvements for the next release of SidechainNet. 
* Improved API
   - for more convenient training, users may access names of all datasplits via `scn.DATA_SPLITS` or the validation entries only via `scn.VALID_SPLITS`. Previously, `VALID_SPLITS` was a list of integers, not split names (i.e. `'valid-10'`).
   - added `complete_structures_only` flag to `scn.load`. If `True`, only loads structures without any missing resides.
* Improved structure building implementation
    - after a more careful reading of Parson et al.'s [paper](https://doi.org/10.1002/jcc.20237), I've implemented self-normalizing NeRF for generating atomic coordinates from angles (may be up to 22% more efficient)
    - Initialize StructureBuilder or BatchedStructureBuilder with `nerf_method='sn_nerf'` to use this method. Default value is `'standard'`.
    - Improved BatchStructureBuilder so that it may still attempt to build structures that are incomplete without erroring
    - Added documentation
 * ~~Improved data~~
   - ~~fix an issue that permitted alpha-carbon only structures to be included in SidechainNet (users should redownload data). Such structures were then missing up to 100% of angle information, since no consecutive atoms were present.~~
   - ~~[example 1 (IJQS)](https://www.rcsb.org/structure/1JQS), [example 2 (1QCR)](https://www.rcsb.org/structure/1QCR), and others~~
   - After some thought, I decided to *keep* such structures with alpha-carbons only. Their angle vectors will contain all 0s, but their coordinate matrices are still correct and can be used to train models if the loss functions are masked correctly. There are 392 SidechainNet/ProteinNet IDs from CASP12 matching this description; I've made a note of them [here (alpha_carbon_only_structures.txt)](https://pitt.box.com/shared/static/pagm781jl4xem7gnpu5y7crvh8rnzwf5.txt)

## Important Changes
  - ProDy must be updated to 2.0 if users would like to use `create.py`. ProDy changed the name of `parseCIF` to `parseMMCIF`.
 
## Todos
  - [x] Improved API
  - [x] Improved structure building implementation
  - [x] ~~Improved data~~

## Status
- [x] Ready to go