### PR TITLE
Implement SCNDataset, SCNProtein, and HydrogenBuilder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ errors/
 *.stride
 *.fa
 sidechainnet/resources/proteinnet*
+*sidechainnet/examples/*ipynb
+sidechainnet_data
+sidechainnet/resources/forcefield_info

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ By default, the `load` function downloads the data from the web into the current
 
 ### Loading SidechainNet as an interactive SCNDataset object
 
-The easiest way to interact with SidechainNet is most likely by using the SCNDataset and
+The easiest way to interact with SidechainNet is most likely by using the `SCNDataset` and
 `SCNProtein` objects. 
 
 ```python

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Specifically, SidechainNet adds measurements for protein angles and coordinates 
 ### Loading SidechainNet as a Python dictionary
 
 ```python
-import sidechainnet as scn
-data = scn.load(casp_version=12, thinning=30)
+>>> import sidechainnet as scn
+>>> data = scn.load(casp_version=12, thinning=30)
 ```
 In its most basic form, SidechainNet is stored as a Python dictionary organized by train, validation, and test splits. These splits are identical to those described in ProteinNet.
  
@@ -86,6 +86,32 @@ data = {"train": {"seq": [seq1, seq2, ...],  # Sequences, 1-letter codes
         }
 ```
 By default, the `load` function downloads the data from the web into the current directory and loads it as a Python dictionary. If the data already exists locally, it reads it from disk. Other than the requirement that the data must be loaded using Python, this method of data loading is agnostic to any downstream analysis.
+
+### Loading SidechainNet as an interactive SCNDataset object
+
+The easiest way to interact with SidechainNet is most likely by using the SCNDataset and
+`SCNProtein` objects. 
+
+```python
+>>> data = scn.load("debug", scn_dataset=True)
+>>> data
+SCNDataset(n=461)
+>>> data["1HD1_1_A"]
+SCNProtein(1HD1_1_A, len=75, missing=0, split='train')
+>>> data[0]
+SCNProtein(2CMY_d2cmyb1, len=23, missing=2, split='train')
+```
+
+Available features:
+* `SCNDataset` is iterable,
+* proteins (`SCNProtein`s) can selected from the dataset by name or index,
+* proteins can be visualized with `.to_3Dmol()` and writable to PDBs with `.to_pdb()`. 
+* non-terminal hydrogens can be added with `SCNProtein.add_hydrogens()`,
+
+Additionally, all of the attributes below are available directly from the `SCNProtein` object:
+* `coords, angles, seq, unmodified_seq, mask, evolutionary, secondary_structure, resolution, is_modified, id, split`
+
+
 
 ### Loading SidechainNet with PyTorch DataLoaders
 The `load` function can also be used to load SidechainNet data as a dictionary of `torch.utils.data.DataLoader` objects. PyTorch `DataLoaders` make it simple to iterate over dataset items for training machine learning models. This method is recommended for using SidechainNet data with PyTorch.

--- a/sidechainnet/dataloaders/SCNDataset.py
+++ b/sidechainnet/dataloaders/SCNDataset.py
@@ -1,0 +1,225 @@
+"""Defines high-level objects for interfacing with raw SidechainNet data.
+
+To utilize SCNDataset, pass scn_dataset=True to scn.load().
+
+    >>> d = scn.load("debug", scn_dataset=True)
+    >>> d
+    SCNDataset(n=461)
+
+SCNProteins may be iterated over or selected from the SCNDataset.
+
+    >>> d["1HD1_1_A"]
+    SCNProtein(1HD1_1_A, len=75, missing=0, split='train')
+
+Available SCNProtein attributes include:
+    * coords
+    * angles
+    * seq
+    * unmodified_seq
+    * mask
+    * evolutionary
+    * secondary_structure
+    * resolution
+    * is_modified
+    * id
+    * split
+
+Other features:
+    * add non-terminal hydrogens to a protein's coordinates with SCNProtein.add_hydrogens
+    * visualize proteins with SCNProtein.to_3Dmol() 
+    * write PDB files for proteins with SCNProtein.to_PDB()
+"""
+import sidechainnet
+import sidechainnet.structure.HydrogenBuilder as hy
+from sidechainnet import structure
+from sidechainnet.structure.build_info import NUM_COORDS_PER_RES
+from sidechainnet.utils.sequence import ONE_TO_THREE_LETTER_MAP
+
+
+class SCNDataset(object):
+    """A representation of a SidechainNet dataset."""
+
+    def __init__(self, data) -> None:
+        """Initialize a SCNDataset from underlying SidechainNet formatted dictionary."""
+        super().__init__()
+        # Determine available datasplits
+        self.splits = []
+        for split_name in ['train', 'valid', 'test']:
+            for k in data.keys():
+                if split_name in k:
+                    self.splits.append(k)
+
+        self.split_to_ids = {}
+        self.ids_to_SCNProtein = {}
+        self.idx_to_SCNProtein = {}
+
+        # Create SCNProtein objects and add to data structure
+        idx = 0
+        for split in self.splits:
+            d = data[split]
+            for c, a, s, u, m, e, n, r, z, i in zip(d['crd'], d['ang'], d['seq'],
+                                                    d['ums'], d['msk'], d['evo'],
+                                                    d['sec'], d['res'], d['mod'],
+                                                    d['ids']):
+                try:
+                    self.split_to_ids[split].append(i)
+                except KeyError:
+                    self.split_to_ids[split] = [i]
+
+                p = SCNProtein(coordinates=c,
+                               angles=a,
+                               sequence=s,
+                               unmodified_seq=u,
+                               mask=m,
+                               evolutionary=e,
+                               secondary_structure=n,
+                               resolution=r,
+                               is_modified=z,
+                               id=i,
+                               split=split)
+                self.ids_to_SCNProtein[i] = p
+                self.idx_to_SCNProtein[idx] = p
+                idx += 1
+
+    def get_protein_list_by_split_name(self, split_name):
+        """Return list of SCNProtein objects belonging to str split_name."""
+        return [p for p in self if p.split == split_name]
+
+    def __getitem__(self, id):
+        """Retrieve a protein by index or ID (name, e.g. '1A9U_1_A')."""
+        if isinstance(id, str):
+            return self.ids_to_SCNProtein[id]
+        elif isinstance(id, slice):
+            step = 1 if not id.step else id.step
+            stop = len(self) if not id.stop else id.stop
+            start = 0 if not id.start else id.start
+            stop = len(self) + stop if stop < 0 else stop
+            start = len(self) + start if start < 0 else start
+            return [self.idx_to_SCNProtein[i] for i in range(start, stop, step)]
+        else:
+            return self.idx_to_SCNProtein[id]
+
+    def __len__(self):
+        """Return number of proteins in the dataset."""
+        return len(self.idx_to_SCNProtein)
+
+    def __iter__(self):
+        """Iterate over SCNProtein objects."""
+        yield from self.ids_to_SCNProtein.values()
+
+    def __repr__(self) -> str:
+        """Represent SCNDataset as a string."""
+        return f"SCNDataset(n={len(self)})"
+
+    def filter_ids(self, to_keep):
+        """Remove proteins whose IDs are not included in list to_keep."""
+        to_delete = []
+        for pnid in self.ids_to_SCNProtein.keys():
+            if pnid not in to_keep:
+                to_delete.append(pnid)
+        for pnid in to_delete:
+            p = self.ids_to_SCNProtein[pnid]
+            self.split_to_ids[p.split].remove(pnid)
+            del self.ids_to_SCNProtein[pnid]
+        self.idx_to_SCNProtein = {}
+        for i, protein in enumerate(self):
+            self.idx_to_SCNProtein[i] = protein
+
+
+class SCNProtein(object):
+    """Represent one protein in SidechainNet. Created programmatically by SCNDataset."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        self.coords = kwargs['coordinates']
+        self.angles = kwargs['angles']
+        self.seq = kwargs['sequence']
+        self.unmodified_seq = kwargs['unmodified_seq']
+        self.mask = kwargs['mask']
+        self.evolutionary = kwargs['evolutionary']
+        self.secondary_structure = kwargs['secondary_structure']
+        self.resolution = kwargs['resolution']
+        self.is_modified = kwargs['is_modified']
+        self.id = kwargs['id']
+        self.split = kwargs['split']
+        self.sb = None
+        self.atoms_per_res = NUM_COORDS_PER_RES
+        self.hcoords = None  # Coordinates with hydrogen atoms
+        self._has_hydrogens = False
+
+    def __len__(self):
+        """Return length of protein sequence."""
+        return len(self.seq)
+
+    def to_3Dmol(self):
+        """Return an interactive visualization of the protein with py3DMol."""
+        if self.sb is None:
+            if self._has_hydrogens:
+                self.sb = sidechainnet.StructureBuilder(self.seq, self.hcoords)
+            else:
+                self.sb = sidechainnet.StructureBuilder(self.seq, self.coords)
+        return self.sb.to_3Dmol()
+
+    def to_pdb(self, path, title=None):
+        """Save structure to path as a PDB file."""
+        if not title:
+            title = self.id
+        if self.sb is None:
+            if self._has_hydrogens:
+                self.sb = sidechainnet.StructureBuilder(self.seq, self.hcoords)
+            else:
+                self.sb = sidechainnet.StructureBuilder(self.seq, self.coords)
+        return self.sb.to_pdb(path, title)
+
+    @property
+    def num_missing(self):
+        """Return number of missing residues."""
+        return self.mask.count("-")
+
+    @property
+    def seq3(self):
+        """Return 3-letter amino acid sequence for the protein."""
+        return " ".join([ONE_TO_THREE_LETTER_MAP[c] for c in self.seq])
+
+    def add_hydrogens(self, coords=None, build_from_angles=False):
+        """Add non-terminal hydrogens to coordinates. Shapes (14L x 3) -> (24L x 3).
+
+        Adds hydrogen atoms to the protein structure coordinate representation. This
+        function essentially converts the coordinate maping schema from one that only
+        includes heavy atoms (i.e., NUM_COORDS_PER_RES = 14 atoms per residue) to one that
+        includes hydrogen atoms (i.e., NUM_COORDS_PER_RES_W_HYDROGENS = 24 atoms per
+        residue). For simplicity, N-terminal hydrogens (H2 and H3) and the terminal oxygen
+        (OXT) are not explicitly included in the atom mapping. Rather, they are stored in
+        StructureBuilder.terminal_atoms, a dictionary mapping terminal atom names to their
+        coordinates.
+
+        See
+        sidechainnet.structure.HydrogenBuilder for more details.
+
+        Args:
+            coords (np.ndarray, torch.tensor, optional): A set of heavy-atom coordinates
+                which can be provided to override the current atom coordinates before
+                adding hydrogens. Defaults to None.
+            build_from_angles (bool, optional): If True, rebuild heavy-atom coordinates
+                from internal angle representaion before adding hydrogens. Defaults to
+                False.
+        """
+        # Initialize a structure builder with heavy-atom coordinates
+        if build_from_angles:
+            self.sb = structure.StructureBuilder(self.seq, ang=self.angles)
+            self.sb.build()
+        elif coords is not None:
+            self.sb = structure.StructureBuilder(self.seq, crd=coords)
+        else:
+            self.sb = structure.StructureBuilder(self.seq, crd=self.coords)
+
+        self.sb.add_hydrogens()
+        self.hcoords = self.sb.coords
+        self._has_hydrogens = True
+        self.atoms_per_res = hy.NUM_COORDS_PER_RES_W_HYDROGENS
+        return self.hcoords
+
+    def __repr__(self) -> str:
+        """Represent an SCNProtein as a string."""
+        return (f"SCNProtein({self.id}, len={len(self)}, missing={self.num_missing}, "
+                f"split='{self.split}')")

--- a/sidechainnet/structure/BatchedStructureBuilder.py
+++ b/sidechainnet/structure/BatchedStructureBuilder.py
@@ -1,11 +1,10 @@
 """A convenience class for generating multiple protein structures simultaneously."""
 
 import numpy as np
-
-from sidechainnet.dataloaders.collate import pad_for_batch
-from sidechainnet.utils.sequence import VOCAB
-from sidechainnet.structure.build_info import NUM_COORDS_PER_RES
 import sidechainnet as scn
+from sidechainnet.dataloaders.collate import pad_for_batch
+from sidechainnet.structure.build_info import NUM_COORDS_PER_RES
+from sidechainnet.utils.sequence import VOCAB
 
 
 class BatchedStructureBuilder(object):

--- a/sidechainnet/structure/HydrogenBuilder.py
+++ b/sidechainnet/structure/HydrogenBuilder.py
@@ -1,0 +1,684 @@
+"""Methods for adding hydrogen atoms to amino acid residues."""
+import math
+
+import numpy as np
+import torch
+from sidechainnet.structure.build_info import BB_BUILD_INFO, NUM_COORDS_PER_RES, SC_BUILD_INFO
+from sidechainnet.structure.structure import coord_generator
+from sidechainnet.utils.measure import GLOBAL_PAD_CHAR
+from sidechainnet.utils.sequence import ONE_TO_THREE_LETTER_MAP
+
+NUM_COORDS_PER_RES_W_HYDROGENS = 24
+
+METHYL_ANGLE = 109.5
+METHYL_LEN = 1.09
+
+METHYLENE_ANGLE = np.rad2deg(0.61656)  # Check - works
+METHYLENE_LEN = 1.09
+
+SP3_LEN = 1.09
+
+THIOL_ANGLE = 109.5
+THIOL_LEN = 1.336
+HYDROXYL_LEN = 0.96
+
+AMIDE_LEN = 1.01  # Backbone
+METHINE_LEN = 1.08
+
+AMINE_ANGLE = np.deg2rad(120)
+AMINE_LEN = 1.01
+
+OXT_LEN = BB_BUILD_INFO['BONDLENS']['c-oh']
+
+# yapf: disable
+HYDROGEN_NAMES = {
+    'ALA': ['H', 'HA', 'HB1', 'HB2', 'HB3'],
+    'ARG': ['H', 'HA', 'HB2', 'HB3', 'HD2', 'HD3', 'HG2', 'HG3', 'HE', 'HH11', 'HH12', 'HH21', 'HH22'],
+    'ASN': ['H', 'HA', 'HB2', 'HB3', 'HD21', 'HD22'],
+    'ASP': ['H', 'HA', 'HB2', 'HB3'],
+    'CYS': ['H', 'HA', 'HB2', 'HB3', 'HG'],
+    'GLN': ['H', 'HA', 'HB2', 'HB3', 'HG2', 'HG3', 'HE21', 'HE22'],
+    'GLU': ['H', 'HA', 'HB2', 'HB3', 'HG2', 'HG3'],
+    'GLY': ['H', 'HA2', 'HA3'],
+    'HIS': ['H', 'HA', 'HB2', 'HB3', 'HE1', 'HD2', 'HD1'],  # CB, CB, CE1, CD2, ND1/HE1
+    'ILE': ['H', 'HA', 'HB', 'HD11', 'HD12', 'HD13', 'HG12', 'HG13', 'HG21', 'HG22', 'HG23'],
+    'LEU': ['H', 'HA', 'HB2', 'HB3', 'HD11', 'HD12', 'HD13', 'HD21', 'HD22', 'HD23', 'HG'],
+    'LYS': ['H', 'HA', 'HB2', 'HB3', 'HD2', 'HD3', 'HE2', 'HE3', 'HG2', 'HG3', 'HZ1', 'HZ2', 'HZ3'],
+    'MET': ['H', 'HA', 'HB2', 'HB3', 'HE1', 'HE2', 'HE3', 'HG2', 'HG3'],
+    'PHE': ['H', 'HA', 'HB2', 'HB3', 'HD1', 'HD2', 'HE1', 'HE2', 'HZ'],
+    'PRO': ['HA', 'HB2', 'HB3', 'HD2', 'HD3', 'HG2', 'HG3'],
+    'SER': ['H', 'HA', 'HB2', 'HB3', 'HG'],
+    'THR': ['H', 'HA', 'HB', 'HG1', 'HG21', 'HG22', 'HG23'],
+    'TRP': ['H', 'HA', 'HB2', 'HB3', 'HD1', 'HE1', 'HE3', 'HH2', 'HZ2', 'HZ3'],
+    'TYR': ['H', 'HA', 'HB2', 'HB3', 'HD1', 'HD2', 'HE1', 'HE2', 'HH'],
+    'VAL': ['H', 'HA', 'HB', 'HG11', 'HG12', 'HG13', 'HG21', 'HG22', 'HG23']
+}
+# yapf: enable
+
+
+class HydrogenBuilder(object):
+    """A class for adding Hydrogen positions to set of coordinates."""
+
+    def __init__(self, seq, coords):
+        """Create a Hydrogen builder for a protein.
+
+        Args:
+            seq (str): Protein sequence.
+            coords (numpy.ndarray, torch.tensor): Coordinate set for a protein that does
+                not yet contain Hydrogens.
+        """
+        from sidechainnet.structure.PdbBuilder import ATOM_MAP_14
+
+        self.seq = seq
+        self.coords = coords
+        self.mode = "torch" if isinstance(coords, torch.Tensor) else "numpy"
+        self.is_numpy = self.mode == "numpy"
+        self.atom_map = ATOM_MAP_14
+        self.terminal_atoms = {"H2": None, "H3": None, "OXT": None}
+        self.empty_coord = np.zeros((3)) if self.is_numpy else torch.zeros(3)
+
+        self.norm = np.linalg.norm if self.is_numpy else torch.norm
+        self.cross = np.cross if self.is_numpy else torch.cross
+        self.dot = np.dot if self.is_numpy else torch.matmul
+        self.eye = np.eye if self.is_numpy else torch.eye
+        self.ones = np.ones if self.is_numpy else torch.ones
+        self.sqrt = math.sqrt if self.is_numpy else torch.sqrt
+        self.stack = np.stack if self.is_numpy else torch.stack
+        self.array = np.asarray if self.is_numpy else torch.tensor
+        self.concatenate = np.concatenate if self.is_numpy else torch.cat
+
+    def build_hydrogens(self):
+        """Add hydrogens to internal protein structure."""
+        # TODO assumes only one continuous chain (and 1 set of N & C terminals)
+        coords = coord_generator(self.coords, NUM_COORDS_PER_RES, remove_padding=True)
+        new_coords = []
+        prev_res_atoms = None
+        for i, (aa, crd) in enumerate(zip(self.seq, coords)):
+            # Add empty hydrogen coordinates for missing residues
+            if crd.sum() == 0:
+                new_coords.append(self.ones((NUM_COORDS_PER_RES_W_HYDROGENS, 3))*0)
+                prev_res_atoms = None
+                continue
+            # Create an organized mapping from atom name to Catesian coordinates
+            d = {name: xyz for (name, xyz) in zip(self.atom_map[aa], crd)}
+            atoms = AtomHolder(d, default=None)  # default=self.empty_coord would allow building hydrogens from missing coords
+            # Generate hydrogen positions as array/tensor
+            hydrogen_positions = self.get_hydrogens_for_res(
+                aa,
+                atoms,
+                prev_res_atoms,
+                n_terminal=i == 0,
+                c_terminal=i == len(self.seq) - 1)
+            # Append Hydrogens immediately after heavy atoms, followed by PADs to L=24
+            new_coords.append(self.concatenate((crd, hydrogen_positions)))
+            prev_res_atoms = atoms
+        self.reduced_coords = self.concatenate(new_coords)
+        return self.reduced_coords
+
+    # Utility functions
+    def M(self, axis, theta):
+        """Create rotation matrix with angle theta around a given axis.
+
+        From https://stackoverflow.com/questions/6802577/rotation-of-3d-vector.
+        """
+        axis = axis / self.sqrt(self.dot(axis, axis))
+        a = np.cos(theta / 2.0)
+        b, c, d = -axis * np.sin(theta / 2.0)
+        aa, bb, cc, dd = a * a, b * b, c * c, d * d
+        bc, ad, ac, ab, bd, cd = b * c, a * d, a * c, a * b, b * d, c * d
+        return self.array([[aa + bb - cc - dd, 2 * (bc + ad), 2 * (bd - ac)],
+                           [2 * (bc - ad), aa + cc - bb - dd, 2 * (cd + ab)],
+                           [2 * (bd + ac), 2 * (cd - ab), aa + dd - bb - cc]])
+
+    def scale(self, vector, target_len, v_len=None):
+        """Scale a vector to match a given target length."""
+        if v_len is None:
+            v_len = self.norm(vector)
+        return vector / v_len * target_len
+
+    # The following base functions are utilized for residues consisting of >=1 H geoms.
+    # There are 6 base hydrogen geometries:
+    #    1. Methyl         (CH3)
+    #    2. Methylene      (R-CH2-R)
+    #    3. Single-sp3     (N-CAH-C)
+    #    4. Hydroxyl/thiol (O-H1, S-H1)
+    #    5. Methine/Amide  (C=CH1-C, C-NH1-C)
+    #    6. Amine          (H2)
+
+    def get_methyl_hydrogens(self, carbon, prev1, prev2, use_amine_length=False):
+        """Place methyl (H3) hydrogens on a Carbon atom. Also supports N-terminal amines.
+
+        Ex: Alanine: carbon, prev1, prev2 are CB, CA, N.
+        """
+        length = METHYL_LEN if not use_amine_length else AMINE_LEN
+
+        # Define local vectors extending from CA
+        N = prev2 - prev1
+        CB = carbon - prev1
+
+        # Define perpendicular vector
+        PV = self.cross(CB, N)
+        R109 = self.M(PV, np.deg2rad(METHYL_ANGLE))  # Rotate abt PV by 109.5 (tetrahed.)
+
+        # Define Hydrogen extending from carbon
+        H1 = self.dot(R109, -CB)  # Place Hydrogen by rotating C along perpendicular axis
+        H1 = self.scale(H1, length)
+
+        R120 = self.M(CB, 2 * np.pi / 3)
+        H2 = self.dot(R120, H1)  # Place 2nd Hydrogen by rotating previous H 120 deg
+        H3 = self.dot(R120, H2)  # Place 3rd Hydrogen by rotating previous H 120 deg
+
+        H1 += prev1 + CB
+        H2 += prev1 + CB
+        H3 += prev1 + CB
+
+        return [H1, H2, H3]
+
+    def get_methylene_hydrogens(self, r1, carbon, r2):
+        """Place methylene hydrogens (R1-CH2-R2) on central Carbon.
+
+        Args:
+            r1: First atom vector.
+            carbon: Second atom vector (Carbon needing hydrogens).
+            r2: Third atom vector.
+
+        Returns:
+            Tuple: Hydrogens extending from central Carbon.
+        """
+        # Define local vectors
+        R1 = r1 - carbon
+        R2 = r2 - carbon
+
+        # Create perpendicular vector
+        PV = self.cross(R1, R2)
+        axis = R2 - R1
+
+        # Place first hydrogen
+        R = self.M(axis, METHYLENE_ANGLE)
+        H1 = self.dot(R, PV)
+        vector_len = self.norm(H1)
+        H1 = self.scale(vector=H1, target_len=METHYLENE_LEN, v_len=vector_len)
+
+        # Place second hydrogen
+        R = self.M(axis, -METHYLENE_ANGLE)
+        H2 = self.dot(R, -PV)
+        H2 = self.scale(vector=H2, target_len=METHYLENE_LEN, v_len=vector_len)
+
+        # Return to original position
+        H1 += carbon
+        H2 += carbon
+
+        return [H1, H2]
+
+    def get_single_sp3_hydrogen(self, center, R1, R2, R3):
+        H1 = self.scale(-(R1 + R2 + R3 - (3 * center)), target_len=SP3_LEN)
+        return H1 + center
+
+    def get_thiol_hydrogen(self, oxy_sulfur, prev1, prev2, thiol=True):
+        if thiol:
+            length = THIOL_LEN
+        else:
+            length = HYDROXYL_LEN
+
+        # Define local vectors
+        OS = oxy_sulfur - prev1
+        P2 = prev2 - prev1
+
+        # Define perpendicular vector  to other
+        PV = self.cross(OS, P2)
+
+        # Define rotation matrices
+        # Rotate around PV by 109.5 (tetrahedral)
+        RP = self.M(PV, np.pi - np.deg2rad(THIOL_ANGLE))
+
+        # Define Hydrogens
+        H1 = self.dot(RP, OS)  # Rotate by tetrahedral angle only
+        H1 = self.scale(H1, length)
+        H1 += OS
+
+        return H1 + prev1
+
+    def get_amide_methine_hydrogen(self, R1, center, R2, amide=True, oxt=False):
+        """Create a planar methine/amide hydrogen (or OXT) given two adjacent atoms."""
+        length = AMIDE_LEN if amide else METHINE_LEN
+        length = OXT_LEN if oxt else length
+
+        # Define local vectors
+        A, B, C = (v - center for v in (R1, center, R2))
+
+        H1 = self.scale(-(A + B + C), target_len=length)
+        return H1 + center
+
+    def get_amine_hydrogens(self, nitrogen, prev1, prev2):
+        # Define local vectors
+        N = nitrogen - prev1
+        P2 = prev2 - prev1
+
+        PV = self.cross(N, P2)
+
+        # Place first hydrogen
+        R = self.M(PV, -AMINE_ANGLE)  # Rotate around perpendicular axis
+        H1 = self.dot(R, -N)
+        vector_len = self.norm(H1)
+        H1 = self.scale(vector=H1, target_len=AMINE_LEN, v_len=vector_len)
+
+        # Rotate the previous vector around the same axis by another 120 degrees
+        H2 = self.dot(R, H1)
+        H2 = self.scale(vector=H2, target_len=AMINE_LEN, v_len=vector_len)
+
+        H1 += prev1 + N
+        H2 += prev1 + N
+
+        return [H1, H2]
+
+    def pad_hydrogens(self, resname, hydrogens):
+        """Pad hydrogen list with empty vectors to the correct length for a given res."""
+
+        pad_vec = [GLOBAL_PAD_CHAR * self.ones(3)]
+        n_heavy_atoms = sum(
+            [True if an != "PAD" else False for an in self.atom_map[resname]])
+        n_pad = NUM_COORDS_PER_RES_W_HYDROGENS - n_heavy_atoms - len(hydrogens)
+        hydrogens.extend(pad_vec * (n_pad))
+        return hydrogens
+
+    def ala(self, c):
+        """Return list of hydrogen positions for ala.
+
+        Positions correspond to the following hydrogens:
+            [HB1, HB2, HB3]
+        """
+        # HB1, HB2, HB3
+        hs = self.get_methyl_hydrogens(carbon=c.CB, prev1=c.CA, prev2=c.N)
+        return hs
+
+    def arg(self, c):
+        """Return list of hydrogen positions for arg.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HD2, HD3, HG2, HG3, HE, HH11, HH12, HH21, HH22]
+        """
+        hs = []
+        # Methylene hydrogens: [HB2, HB3, HD2, HD3, HG2, HG3]
+        for R1, carbon, R2 in [
+            (c.CA, c.CB, c.CG),
+            (c.CG, c.CD, c.NE),
+            (c.CB, c.CG, c.CD),
+        ]:
+            hs.extend(self.get_methylene_hydrogens(R1, carbon, R2))
+        # Amide hydrogen: HE
+        hs.append(self.get_amide_methine_hydrogen(c.CD, c.NE, c.CZ, amide=True))
+        # Amine hydrogens: [HH11, HH12, HH21, HH22]
+        hs.extend(self.get_amine_hydrogens(c.NH1, c.CZ, c.NE))
+        hs.extend(self.get_amine_hydrogens(c.NH2, c.CZ, c.NE))
+
+        return hs
+
+    def asn(self, c):
+        """Return list of hydrogen positions for asn.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HD21, HD22]
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        # Amine: [HD21, HD22]
+        hs.extend(self.get_amine_hydrogens(c.ND2, c.CG, c.CB))
+        return hs
+
+    def asp(self, c):
+        """Return list of hydrogen positions for asp.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3]
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        return hs
+
+    def cys(self, c):
+        """Return list of hydrogen positions for cys.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HG]
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.SG))
+        # Thiol: HG
+        hs.append(self.get_thiol_hydrogen(c.SG, c.CB, c.CA))
+        return hs
+
+    def gln(self, c):
+        """Return list of hydrogen positions for gln.
+
+        Positions correspond to the following hydrogens:
+            ['HB2', 'HB3', 'HG2', 'HG3', 'HE21', 'HE22']
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        # Methylene: [HG2, HG3]
+        hs.extend(self.get_methylene_hydrogens(c.CB, c.CG, c.CD))
+        # Amine: [HE21, HE22]
+        hs.extend(self.get_amine_hydrogens(c.NE2, c.CD, c.CG))
+        return hs
+
+    def glu(self, c):
+        """Return list of hydrogen positions for glu.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HG2, HG3]
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        # Methylene: [HG2, HG3]
+        hs.extend(self.get_methylene_hydrogens(c.CB, c.CG, c.CD))
+        return hs
+
+    def gly(self, c):
+        """Return list of hydrogen positions for gly.
+
+        Positions correspond to the following hydrogens:
+            [HA2, HA3]
+        """
+        return self.get_methylene_hydrogens(c.N, c.CA, c.C)
+
+    def his(self, c):
+        """Return list of hydrogen positions for his.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HE1, HD2, HD1] # CB, CB, CE1, CD2, (ND1/HD1)
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        # Methine x2: [HE1, HD2]
+        hs.append(self.get_amide_methine_hydrogen(c.ND1, c.CE1, c.NE2, amide=False))
+        hs.append(self.get_amide_methine_hydrogen(c.CG, c.CD2, c.NE2, amide=False))
+        # Amide: [HD1]
+        hs.append(self.get_amide_methine_hydrogen(c.CG, c.ND1, c.CE1, amide=True))
+        return hs
+
+    def ile(self, c):
+        """Return list of hydrogen positions for ile.
+
+        Positions correspond to the following hydrogens:
+            [HB, HD11, HD12, HD13, HG12, HG13, HG21, HG22, HG23]
+        """
+        hs = []
+        # HB
+        hs.append(self.get_single_sp3_hydrogen(c.CB, c.CA, c.CG1, c.CG2))
+        # HD11, HD12, HD13
+        hs.extend(self.get_methyl_hydrogens(c.CD1, c.CG1, c.CB))
+        # Methylene: HG12, HG13
+        hs.extend(self.get_methylene_hydrogens(c.CB, c.CG1, c.CD1))
+        # Methyl: HG21, HG22, HG23
+        hs.extend(self.get_methyl_hydrogens(c.CG2, c.CB, c.CA))
+        return hs
+
+    def leu(self, c):
+        """Return list of hydrogen positions for leu.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HD11, HD12, HD13, HD21, HD22, HD23, HG]
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        # Methyl: HD11, HD12, HD13
+        hs.extend(self.get_methyl_hydrogens(c.CD1, c.CG, c.CB))
+        # Methyl: HD21, HD22, HD23
+        hs.extend(self.get_methyl_hydrogens(c.CD2, c.CG, c.CB))
+        # SP3: HG
+        hs.append(self.get_single_sp3_hydrogen(c.CG, c.CB, c.CD1, c.CD2))
+        return hs
+
+    def lys(self, c):
+        """Return list of hydrogen positions for lys.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HD2, HD3, HE2, HE3, HG2, HG3, HZ1, HZ2, HZ3]
+        """
+        hs = []
+        # Methylene x4: [HB2, HB3], [HD2, HD3], [HE2, HE3], [HG2, HG3] ie (CB, CD, CE, CG)
+        for r1, carbon, r2 in ((c.CA, c.CB, c.CG), (c.CG, c.CD, c.CE), (c.CD, c.CE, c.NZ),
+                               (c.CB, c.CG, c.CD)):
+            hs.extend(self.get_methylene_hydrogens(r1, carbon, r2))
+        # NH3: HZ1, HZ2, HZ3
+        hs.extend(self.get_methyl_hydrogens(c.NZ, c.CE, c.CD))
+        return hs
+
+    def met(self, c):
+        """Return list of hydrogen positions for met.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HE1, HE2, HE3, HG2, HG3]
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        # Methyl: HE1, HE2, HE3
+        hs.extend(self.get_methyl_hydrogens(c.CE, c.SD, c.CG))
+        # Methylene: HG2, HG3
+        hs.extend(self.get_methylene_hydrogens(c.CB, c.CG, c.SD))
+        return hs
+
+    def phe(self, c):
+        """Return list of hydrogen positions for phe.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HD1, HD2, HE1, HE2, HZ]
+        """
+        hs = []
+        # Methylene: HB2, HB3
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        # Methine x 5: HD1, HD2, HE1, HE2, HZ
+        for r1, center, r2 in ((c.CG, c.CD1, c.CE1), (c.CG, c.CD2, c.CE2),
+                               (c.CD1, c.CE1, c.CZ), (c.CD2, c.CE2, c.CZ), (c.CE1, c.CZ,
+                                                                            c.CE2)):
+            hs.append(self.get_amide_methine_hydrogen(r1, center, r2, amide=False))
+        return hs
+
+    def pro(self, c):
+        """Return list of hydrogen positions for pro.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HD2, HD3, HG2, HG3]
+        """
+        hs = []
+        # Methylene x6: [HB2, HB3], [HD2, HD3], [HG2, HG3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        hs.extend(self.get_methylene_hydrogens(c.N, c.CD, c.CG))
+        hs.extend(self.get_methylene_hydrogens(c.CD, c.CG, c.CB))
+        return hs
+
+    def ser(self, c):
+        """Return list of hydrogen positions for ser.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HG]
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.OG))
+        # Hydroxyl: HG
+        hs.append(self.get_thiol_hydrogen(c.OG, c.CB, c.CA, thiol=False))
+        return hs
+
+    def thr(self, c):
+        """Return list of hydrogen positions for thr.
+
+        Positions correspond to the following hydrogens:
+            [HB, HG1, HG21, HG22, HG23]
+        """
+        hs = []
+        # SP3: HB
+        hs.append(self.get_single_sp3_hydrogen(c.CB, c.CA, c.OG1, c.CG2))
+        # Hydroxyl: HG1
+        hs.append(self.get_thiol_hydrogen(c.OG1, c.CB, c.CA, thiol=False))
+        # Methyl: HG21, HG22, HG23
+        hs.extend(self.get_methyl_hydrogens(c.CG2, c.CB, c.CA))
+        return hs
+
+    def trp(self, c):
+        """Return list of hydrogen positions for trp.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HD1, HE1, HE3, HH2, HZ2, HZ3]
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        # Methine: HD1
+        hs.append(self.get_amide_methine_hydrogen(c.CG, c.CD1, c.NE1, amide=False))
+        # Amide/methine: HE1
+        hs.append(self.get_amide_methine_hydrogen(c.CD1, c.NE1, c.CE2, amide=True))
+        # Methine: HE3
+        hs.append(self.get_amide_methine_hydrogen(c.CD2, c.CE3, c.CZ3, amide=False))
+        # Methine: HH2
+        hs.append(self.get_amide_methine_hydrogen(c.CZ3, c.CH2, c.CZ2, amide=False))
+        # Methine HZ2
+        hs.append(self.get_amide_methine_hydrogen(c.CE2, c.CZ2, c.CH2, amide=False))
+        # Methine: HZ3
+        hs.append(self.get_amide_methine_hydrogen(c.CE3, c.CZ3, c.CH2, amide=False))
+        return hs
+
+    def tyr(self, c):
+        """Return list of hydrogen positions for tyr.
+
+        Positions correspond to the following hydrogens:
+            [HB2, HB3, HD1, HD2, HE1, HE2, HH]
+        """
+        hs = []
+        # Methylene: [HB2, HB3]
+        hs.extend(self.get_methylene_hydrogens(c.CA, c.CB, c.CG))
+        # Methine x4: HD1, HD2, HE1, HE2
+        hs.append(self.get_amide_methine_hydrogen(c.CG, c.CD1, c.CE1, amide=False))
+        hs.append(self.get_amide_methine_hydrogen(c.CG, c.CD2, c.CE2, amide=False))
+        hs.append(self.get_amide_methine_hydrogen(c.CD1, c.CE1, c.CZ, amide=False))
+        hs.append(self.get_amide_methine_hydrogen(c.CD2, c.CE2, c.CZ, amide=False))
+        # Hydroxyl: HH
+        hs.append(self.get_thiol_hydrogen(c.OH, c.CZ, c.CE1, thiol=False))
+        return hs
+
+    def val(self, c):
+        """Return list of hydrogen positions for val.
+
+        Positions correspond to the following hydrogens:
+            [HB, HG11, HG12, HG13, HG21, HG22, HG23]
+        """
+        hs = []
+        # SP3: HB
+        hs.append(self.get_single_sp3_hydrogen(c.CB, c.CA, c.CG1, c.CG2))
+        # Methyl  x2: [HG11, HG12, HG13], [HG21, HG22, HG23]
+        hs.extend(self.get_methyl_hydrogens(c.CG1, c.CB, c.CA))
+        hs.extend(self.get_methyl_hydrogens(c.CG2, c.CB, c.CA))
+        return hs
+
+    def get_hydrogens_for_res(self,
+                              resname,
+                              c,
+                              prevc,
+                              n_terminal=False,
+                              c_terminal=False):
+        """Return a padded array of hydrogens for a given res name & atom coord tuple."""
+        hs = []
+        # Special Cases
+        if n_terminal:
+            h, h2, h3 = self.get_methyl_hydrogens(c.N, c.CA, c.C, use_amine_length=True)
+            self.terminal_atoms.update({"H2": h2, "H3": h3})
+            hs.append(h)  # Used as normal amine hydrogen, H
+        if c_terminal:
+            oxt = self.get_amide_methine_hydrogen(c.CA, c.C, c.O, oxt=True)
+            self.terminal_atoms.update({"OXT": oxt})
+        # All amino acids except proline have an amide-hydrogen along the backbone
+        if prevc and resname != "P":
+            hs.append(self.get_amide_methine_hydrogen(prevc.C, c.N, c.CA, amide=True))
+        # If the amino acid is not Glycine, we can add an sp3-hybridized H to CA
+        if resname != "G":
+            cah = self.get_single_sp3_hydrogen(center=c.CA, R1=c.N, R2=c.C, R3=c.CB)
+            hs.append(cah)
+
+        # Now, we can add the remaining unique hydrogens for each amino acid
+        if resname == "A":
+            hs.extend(self.ala(c))
+        elif resname == "R":
+            hs.extend(self.arg(c))
+        elif resname == "N":
+            hs.extend(self.asn(c))
+        elif resname == "D":
+            hs.extend(self.asp(c))
+        elif resname == "C":
+            hs.extend(self.cys(c))
+        elif resname == "E":
+            hs.extend(self.glu(c))
+        elif resname == "Q":
+            hs.extend(self.gln(c))
+        elif resname == "G":
+            hs.extend(self.gly(c))
+        elif resname == "H":
+            hs.extend(self.his(c))
+        elif resname == "I":
+            hs.extend(self.ile(c))
+        elif resname == "L":
+            hs.extend(self.leu(c))
+        elif resname == "K":
+            hs.extend(self.lys(c))
+        elif resname == "M":
+            hs.extend(self.met(c))
+        elif resname == "F":
+            hs.extend(self.phe(c))
+        elif resname == "P":
+            hs.extend(self.pro(c))
+        elif resname == "S":
+            hs.extend(self.ser(c))
+        elif resname == "T":
+            hs.extend(self.thr(c))
+        elif resname == "W":
+            hs.extend(self.trp(c))
+        elif resname == "Y":
+            hs.extend(self.tyr(c))
+        elif resname == "V":
+            hs.extend(self.val(c))
+
+        return self.stack(self.pad_hydrogens(resname, hs), 0)
+
+
+class AtomHolder(dict):
+    """A defaultdict that also allows keys to be accessed like attributes.
+
+    Used to map atom names to their coordinates. If an atom doesn't exist, returns a 
+    default value. Inspired by:
+    https://stackoverflow.com/questions/2352181/how-to-use-a-dot-to-access-members-of-dictionary.
+    """
+
+    def __init__(self, dictionary, default):
+        for k, v in dictionary.items():
+            self[k] = v
+        self.default = default
+
+    def __getattr__(self, name):
+        if name in self:
+            return self[name]
+        elif self.default:
+            return self.default.copy()
+        else:
+            raise AttributeError(f"No attribute named {name}.")
+
+    def __setattr__(self, key, value):
+        self.__setitem__(key, value)
+
+    def __setitem__(self, key, value):
+        super(AtomHolder, self).__setitem__(key, value)
+        self.__dict__.update({key: value})
+
+
+ATOM_MAP_24 = {}
+for one_letter, three_letter in ONE_TO_THREE_LETTER_MAP.items():
+    ATOM_MAP_24[one_letter] = ["N", "CA", "C", "O"] + list(
+        SC_BUILD_INFO[ONE_TO_THREE_LETTER_MAP[one_letter]]["atom-names"])
+    ATOM_MAP_24[one_letter].extend(HYDROGEN_NAMES[three_letter])
+    ATOM_MAP_24[one_letter].extend(["PAD"] * (24 - len(ATOM_MAP_24[one_letter])))

--- a/sidechainnet/structure/structure.py
+++ b/sidechainnet/structure/structure.py
@@ -5,6 +5,7 @@ import prody as pr
 import torch
 from sidechainnet.structure import StructureBuilder
 from sidechainnet.structure.build_info import NUM_ANGLES
+from sidechainnet.utils.measure import GLOBAL_PAD_CHAR
 from sidechainnet.utils.sequence import VOCAB
 
 
@@ -246,6 +247,18 @@ def debug_example():
     ang = d["train"]["ang"][70]
     sb = StructureBuilder.StructureBuilder(seq, ang)
     sb.build()
+
+
+def coord_generator(coords, atoms_per_res=14, remove_padding=False):
+    """Return a generator to iteratively yield self.atoms_per_res atoms at a time."""
+    coord_idx = 0
+    while coord_idx < coords.shape[0]:
+        _slice = coords[coord_idx:coord_idx + atoms_per_res]
+        if remove_padding:
+            non_pad_locs = (_slice != GLOBAL_PAD_CHAR).any(axis=1)
+            _slice = _slice[non_pad_locs]
+        yield _slice
+        coord_idx += atoms_per_res
 
 
 if __name__ == '__main__':

--- a/sidechainnet/tests/test_hydrogens.py
+++ b/sidechainnet/tests/test_hydrogens.py
@@ -1,0 +1,22 @@
+import torch
+import sidechainnet as scn
+
+
+def test_add_hydrogen_numpy():
+    d = scn.load("debug",
+                 scn_dir="/home/jok120/openmm_loss/sidechainnet_data",
+                 scn_dataset=True)
+    p = d['40#2BDS_1_A']  # Starts with 2 Alanines
+    p.coords = p.coords[:28, :]
+    p.seq = p.seq[:2]
+    p.add_hydrogens()
+
+
+def test_add_hydrogen_torch():
+    d = scn.load("debug",
+                 scn_dir="/home/jok120/openmm_loss/sidechainnet_data",
+                 scn_dataset=True)
+    p = d['40#2BDS_1_A']  # Starts with 2 Alanines
+    p.coords = torch.tensor(p.coords[:28, :])
+    p.seq = p.seq[:2]
+    p.add_hydrogens()

--- a/sidechainnet/utils/load.py
+++ b/sidechainnet/utils/load.py
@@ -2,6 +2,7 @@
 
 import pickle
 import os
+from sidechainnet.dataloaders.SCNDataset import SCNDataset
 
 import requests
 import tqdm
@@ -101,7 +102,8 @@ def load(casp_version=12,
          train_eval_downsample=.2,
          filter_by_resolution=False,
          complete_structures_only=False,
-         local_scn_path=None):
+         local_scn_path=None,
+         scn_dataset=False):
     #: Okay
     """Load and return the specified SidechainNet dataset as a dictionary or DataLoaders.
 
@@ -179,6 +181,9 @@ def load(casp_version=12,
             splits. Default False.
         local_scn_path (str, optional): The path for a locally saved SidechainNet file.
             This is especially useful for loading custom SidechainNet datasets.
+        scn_dataset (bool, optional): If True, return a sidechainnet.SCNDataset object
+            for conveniently accessing properties of the data.
+            (See sidechainnet.SCNDataset) for more information.
 
     Returns:
         A Python dictionary that maps data splits ('train', 'test', 'train-eval',
@@ -261,8 +266,10 @@ def load(casp_version=12,
         scn_dict = filter_dictionary_by_missing_residues(scn_dict)
 
     # By default, the load function returns a dictionary
-    if not with_pytorch:
+    if not with_pytorch and not scn_dataset:
         return scn_dict
+    elif not with_pytorch and scn_dataset:
+        return SCNDataset(scn_dict)
 
     if with_pytorch == "dataloaders":
         return prepare_dataloaders(

--- a/sidechainnet/utils/organize.py
+++ b/sidechainnet/utils/organize.py
@@ -10,6 +10,19 @@ import numpy as np
 
 from sidechainnet.utils.download import determine_pnid_type
 
+EMPTY_SPLIT_DICT = {
+    "seq": [],
+    "ang": [],
+    "ids": [],
+    "evo": [],
+    "msk": [],
+    "crd": [],
+    "sec": [],
+    "res": [],
+    "ums": [],
+    "mod": []
+}
+
 
 def validate_data_dict(data):
     """Performs several sanity checks on the data dict before saving."""
@@ -34,29 +47,17 @@ def validate_data_dict(data):
 def create_empty_dictionary():
     """Create an empty SidechainNet dictionary ready to hold SidechainNet data."""
     from sidechainnet.utils.download import VALID_SPLITS
-    basic_data_entries = {
-        "seq": [],
-        "ang": [],
-        "ids": [],
-        "evo": [],
-        "msk": [],
-        "crd": [],
-        "sec": [],
-        "res": [],
-        "ums": [],
-        "mod": []
-    }
 
     data = {
-        "train": copy.deepcopy(basic_data_entries),
-        "test": copy.deepcopy(basic_data_entries),
+        "train": copy.deepcopy(EMPTY_SPLIT_DICT),
+        "test": copy.deepcopy(EMPTY_SPLIT_DICT),
         # To parse date, use datetime.datetime.strptime(date, "%I:%M%p on %B %d, %Y")
         "date": datetime.datetime.now().strftime("%I:%M%p %b %d, %Y"),
         "settings": dict()
     }
 
     validation_subdict = {
-        vsplit: copy.deepcopy(basic_data_entries) for vsplit in VALID_SPLITS
+        vsplit: copy.deepcopy(EMPTY_SPLIT_DICT) for vsplit in VALID_SPLITS
     }
     data.update(validation_subdict)
 


### PR DESCRIPTION
## Description
This pull request does three things:

1. Implements SCNDataset for easier data access (`data = scn.load(... scn_dataset=True)`).
2. Implements SCNProtein for easier data manipulation (access attributes, etc.).
3. Implements HydrogenBuilder. To add hydrogens to any coordinate set for a protein, simply use `SCNProtein.add_hydrogens()`. Note: the coordinate representation for the all-atom structure with hydrogens (`SCNProtein.hcoords`) does not include terminal-specific atoms (H2, H3, OXT). These are included in generated visualization/PDB file, but not in the coordinate set itself.
 
Please see the respective functions for more details.
