### PR TITLE
check all XYZ coords in PDBbuilder

### DIFF
--- a/sidechainnet/structure/PdbBuilder.py
+++ b/sidechainnet/structure/PdbBuilder.py
@@ -108,7 +108,7 @@ class PdbBuilder(object):
         residue_lines = []
         for atom_name, atom_coord in zip(atom_names, coords):
             if (atom_name == "PAD" or np.isnan(atom_coord).sum() > 0 or
-                    np.all(atom_coord==0):
+                    np.all(atom_coord == 0):
                 continue
             residue_lines.append(self._get_line_for_atom(res_name, atom_name, atom_coord))
             self.atom_nbr += 1

--- a/sidechainnet/structure/PdbBuilder.py
+++ b/sidechainnet/structure/PdbBuilder.py
@@ -108,7 +108,7 @@ class PdbBuilder(object):
         residue_lines = []
         for atom_name, atom_coord in zip(atom_names, coords):
             if (atom_name == "PAD" or np.isnan(atom_coord).sum() > 0 or
-                    atom_coord.sum() == 0):
+                    np.all(atom_coord==0):
                 continue
             residue_lines.append(self._get_line_for_atom(res_name, atom_name, atom_coord))
             self.atom_nbr += 1


### PR DESCRIPTION
## Description
I've been using sidechainet to improve sidechain prediction for molecular dynamics data, and have been using PdbBuilder.py to output a final pdb. However, I've found that every 1000 frames or so there will be one atom missing from the outputted pdb.
I've tracked the issue to the following lines in PdbBuilder.py, which checks for a (0,0,0) position by looking at the row sum. However, if the XYZ coordinates happen to sum to zero (which I've found does happen occasionally) then the function will interpret this as a missing atom.

## Todos
Ensure all XYZ values are equal to zero, not just their sum.

## Status
- [ ] Ready to go